### PR TITLE
Fix osx library extension name

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 if [[ `uname` == 'Darwin' ]]; then
-	sed -i 's/-soname/-install_name/g' Makefile
-	sed -i 's/libsvm.so.$(SHVER)/libsvm.$(SHVER).dylib/g' Makefile
+	sed -i '' 's/-soname/-install_name/g' Makefile
+	sed -i '' 's/libsvm.so.$(SHVER)/libsvm.$(SHVER).dylib/g' Makefile
 fi
 make all
 make lib

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,14 +1,23 @@
 #!/bin/bash
 
+if [[ `uname` == 'Darwin' ]]; then
+	sed -i 's/-soname/-install_name/g' Makefile
+	sed -i 's/libsvm.so.$(SHVER)/libsvm.$(SHVER).dylib/g' Makefile
+fi
 make all
 make lib
 # there is no make check or something similar and no make install
 
 mkdir -p $PREFIX/share/licenses/libsvm $PREFIX/lib $PREFIX/include $PREFIX/bin
-install -m644 libsvm.so.* $PREFIX/lib/
 install -m644 svm.h $PREFIX/include/svm.h
 install -m644 COPYRIGHT $PREFIX/share/licenses/libsvm/LICENSE
 install -m755 svm-train $PREFIX/bin/
 install -m755 svm-scale $PREFIX/bin/
 install -m755 svm-predict $PREFIX/bin/
-ln -s libsvm.so.* $PREFIX/lib/libsvm.so
+if [[ `uname` == 'Darwin' ]]; then
+	install -m644 libsvm.2.dylib $PREFIX/lib/
+	ln -s libsvm.2.dylib $PREFIX/lib/libsvm.dylib
+else
+	install -m644 libsvm.so.2 $PREFIX/lib/
+	ln -s libsvm.so.2 $PREFIX/lib/libsvm.so
+fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,8 +30,10 @@ test:
 
   commands:
     - test -e $PREFIX/include/svm.h                           # [unix]
-    - test -e $PREFIX/lib/libsvm.so                           # [unix]
-    - test -e $PREFIX/lib/libsvm.so.2                         # [unix]
+    - test -e $PREFIX/lib/libsvm.so                           # [linux]
+    - test -e $PREFIX/lib/libsvm.so.2                         # [linux]
+    - test -e $PREFIX/lib/libsvm.dylib                        # [osx]
+    - test -e $PREFIX/lib/libsvm.2.dylib                      # [osx]
     - svm-train | grep 'Usage'                                # [unix]
     - svm-scale | grep 'Usage'                                # [unix]
     - svm-predict | grep 'Usage'                              # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - win32.patch  # [win32]
 
 build:
-  number: 0
+  number: 1
   features:
     - vc9   # [win and py27]
     - vc10  # [win and py34]


### PR DESCRIPTION
In OSX shared libraries are named `*.dylib`, this patch fixes that.